### PR TITLE
[#1279] Fix Explorer's HTTP redirects

### DIFF
--- a/server-rules.conf
+++ b/server-rules.conf
@@ -33,6 +33,7 @@ location / {
 }
 location /explorer/ {
     proxy_pass http://os-explorer:8000/;
+    proxy_redirect / /explorer/;
 }
 location /admin/ {
     proxy_pass http://os-admin:8000/;


### PR DESCRIPTION
os-explorer doesn't know it's not being hosted in the root URL (`/`), so when it
does HTTP redirects, it redirects to the root URI. For example, a redirect to
`/search` would have header `Location: /search`, when it should be `Location:
/explorer/search`, considering the application lives in `/explorer`.

Nginx's `proxy_redirect` serves to fix this issue.

openspending/openspending#1279