### PR TITLE
Remove /pipelines/ endpoint

### DIFF
--- a/server-rules.conf
+++ b/server-rules.conf
@@ -114,17 +114,6 @@ location = /fdp-adapter {
     proxy_set_header X-Forwarded-For $remote_addr;
 }
 
-location ^~ /pipelines/ {
-    proxy_pass http://os-data-importers:5000/;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $remote_addr;
-}
-location = /pipelines {
-    proxy_pass http://os-data-importers:5000/;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $remote_addr;
-}
-
 #location ^~ /sealer/ {
 #    proxy_pass http://sealer:3000/;
 #    proxy_set_header Host $host;


### PR DESCRIPTION
os-data-importers (pipelines) will be removed from the Openspending application, when it moves to its own Helm chart (https://github.com/okfn/devops/pull/222).

Closes https://github.com/openspending/openspending/issues/1408